### PR TITLE
add docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+FROM --platform=amd64 rust:1.66-bullseye as build
+
+RUN apt update && \
+    apt install ffmpeg clang libavutil-dev libavformat-dev libavfilter-dev libavdevice-dev libswresample-dev libswscale-dev libavcodec-dev -y
+
+WORKDIR /work
+
+COPY ./ ./
+
+# build for release
+RUN cd oddity-rtsp-server && \
+    cargo build --release
+
+FROM --platform=amd64 debian:bullseye-slim
+
+ENV LOG="oddity_rtsp_server=info"
+
+RUN apt update && \
+    apt install ffmpeg  -y
+
+# copy the build artifact from the build stage
+COPY --from=build /work/oddity-rtsp-server/target/release/oddity-rtsp-server /
+
+# set the startup command to run your binary
+CMD ["/oddity-rtsp-server"]


### PR DESCRIPTION
Add a docker build file to run on container infra in order to avoid issues with ffmpeg dependencies. Image is still big about 500MB but mainly due to ffmpeg.

To build (adjust tags as needed):
```
docker build  -t remiphilippe/oddity-rtsp-server:v1 -t remiphilippe/oddity-rtsp-server:latest .
```

To run:
```
docker run --platform linux/amd64 -p 5554:5554 --mount type=bind,source=/Users/remi/Code/rust/oddity-rtsp/config.yaml,target=/config.yaml remiphilippe/oddity-rtsp-server /oddity-rtsp-server /config.yaml
```

Note: this only supports amd64, on M1 (arm64) there is an error for u8 vs i8 in video-rs:
```
#19 45.01 error[E0308]: arguments to this function are incorrect
#19 45.01    --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/video-rs-0.1.8/src/ffi.rs:405:5
#19 45.01     |
#19 45.01 405 |     av_opt_flag_is_set(
#19 45.01     |     ^^^^^^^^^^^^^^^^^^
#19 45.01     |
#19 45.01 note: expected `u8`, found `i8`
#19 45.01    --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/video-rs-0.1.8/src/ffi.rs:407:7
#19 45.01     |
#19 45.01 407 |       "rtpflags".as_ptr() as *const i8,
#19 45.01     |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#19 45.01     = note: expected raw pointer `*const u8`
#19 45.01                found raw pointer `*const i8`
#19 45.01 note: expected `u8`, found `i8`
#19 45.01    --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/video-rs-0.1.8/src/ffi.rs:408:7
#19 45.01     |
#19 45.01 408 |       "h264_mode0".as_ptr() as *const i8,
#19 45.01     |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#19 45.01     = note: expected raw pointer `*const u8`
#19 45.01                found raw pointer `*const i8`
#19 45.01 note: function defined here
#19 45.01    --> /work/oddity-rtsp-server/target/release/build/ffmpeg-sys-next-31317e395ec752c8/out/bindings.rs:3:546412
#19 45.01     |
#19 45.01 3   | ...free (obj : * mut libc :: c_void) ; } extern "C" { pub fn av_opt_flag_is_set (obj : * mut libc :: c_void , field_name : * const libc :...
#19 45.01     |                                                              ^^^^^^^^^^^^^^^^^^
#19 45.01 
#19 45.02 error[E0308]: mismatched types
#19 45.02    --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/video-rs-0.1.8/src/ffi.rs:552:7
#19 45.02     |
#19 45.02 547 |     let ret = av_log_format_line2(
#19 45.02     |               ------------------- arguments to this function are incorrect
#19 45.02 ...
#19 45.02 552 |       line.as_mut_ptr(),
#19 45.02     |       ^^^^^^^^^^^^^^^^^ expected `u8`, found `i8`
#19 45.02     |
#19 45.02     = note: expected raw pointer `*mut u8`
#19 45.02                found raw pointer `*mut i8`
#19 45.02 note: function defined here
#19 45.02    --> /work/oddity-rtsp-server/target/release/build/ffmpeg-sys-next-31317e395ec752c8/out/bindings.rs:3:167097
#19 45.02     |
#19 45.02 3   | ...nt_prefix : * mut libc :: c_int) ; } extern "C" { pub fn av_log_format_line2 (ptr : * mut libc :: c_void , level : libc :: c_int , fmt...
#19 45.02     |                                                             ^^^^^^^^^^^^^^^^^^^
#19 45.02 
#19 45.02 error[E0308]: mismatched types
#19 45.02    --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/video-rs-0.1.8/src/ffi.rs:558:40
#19 45.02     |
#19 45.02 558 |       if let Ok(line) = CStr::from_ptr(line.as_mut_ptr()).to_str() {
#19 45.02     |                         -------------- ^^^^^^^^^^^^^^^^^ expected `u8`, found `i8`
#19 45.02     |                         |
#19 45.02     |                         arguments to this function are incorrect
#19 45.02     |
#19 45.02     = note: expected raw pointer `*const u8`
#19 45.02                found raw pointer `*mut i8`
#19 45.02 note: associated function defined here
#19 45.02 
#19 45.03 For more information about this error, try `rustc --explain E0308`.
#19 45.04 error: could not compile `video-rs` due to 3 previous errors
#19 45.04 warning: build failed, waiting for other jobs to finish...
```