### PR TITLE
inject parameter sets 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["oddity-rtsp-protocol", "oddity-rtsp-server", "oddity-sdp-protocol"]
 oddity-rtsp-protocol = { path = "oddity-rtsp-protocol", version = "0.1.0" }
 oddity-rtsp-server = { path = "oddity-rtsp-server", version = "0.1.0" }
 oddity-sdp-protocol = { path = "oddity-sdp-protocol", version = "0.1.0" }
-video-rs = "^0.10.3"
+video-rs = "^0.10.5"
 
 [profile.release]
 panic = "abort"

--- a/oddity-rtsp-protocol/src/tokio.rs
+++ b/oddity-rtsp-protocol/src/tokio.rs
@@ -60,7 +60,7 @@ impl<T: Target> Decoder for Codec<T> {
             State::ParseMessage => match self.parser.parse(src)? {
                 Status::Done => {
                     self.state = State::Init;
-                    let parser = std::mem::replace(&mut self.parser, Parser::<T::Inbound>::new());
+                    let parser = std::mem::take(&mut self.parser);
                     Ok(Some(
                         parser
                             .into_message()

--- a/oddity-rtsp-server/src/media/video/rtp_muxer.rs
+++ b/oddity-rtsp-server/src/media/video/rtp_muxer.rs
@@ -3,7 +3,8 @@
 use tokio::task;
 
 use video_rs as video;
-use video_rs::rtp::{RtpMuxer, RtpMuxerBuilder};
+use video_rs::rtp::RtpMuxer as BlockingRtpMuxer;
+pub use video_rs::rtp::RtpMuxerBuilder;
 
 type Result<T> = std::result::Result<T, video::Error>;
 
@@ -11,20 +12,87 @@ pub async fn make_rtp_muxer_builder() -> Result<RtpMuxerBuilder> {
     task::spawn_blocking(RtpMuxerBuilder::new).await.unwrap()
 }
 
-pub async fn muxed(
-    mut rtp_muxer: RtpMuxer,
-    packet: video::Packet,
-) -> (RtpMuxer, Result<Vec<video::rtp::RtpBuf>>) {
-    task::spawn_blocking(move || {
-        let out = rtp_muxer.mux(packet);
-        (rtp_muxer, out)
-    })
-    .await
-    .unwrap()
+pub struct RtpMuxer {
+    inner: BlockingRtpMuxer,
+    sps_packet_annex_b: Option<Vec<u8>>,
+    pps_packet_annex_b: Option<Vec<u8>>,
 }
 
-pub async fn finish(mut rtp_muxer: RtpMuxer) -> Result<Option<Vec<video::rtp::RtpBuf>>> {
-    task::spawn_blocking(move || rtp_muxer.finish())
+impl RtpMuxer {
+    pub fn from_builder(rtp_muxer_builder: RtpMuxerBuilder) -> Result<RtpMuxer> {
+        let blocking_muxer = rtp_muxer_builder.build();
+
+        let mut parameter_sets = blocking_muxer.parameter_sets_h264();
+        let (sps_packet, pps_packet) = if !parameter_sets.is_empty() {
+            let (sps, ppss) = parameter_sets.remove(0)?;
+
+            let mut sps_packet = vec![0, 0, 0, 1]; // annex b start code
+            sps_packet.extend_from_slice(sps);
+
+            let mut pps_packet = Vec::new();
+            for pps in ppss {
+                pps_packet.extend_from_slice(&[0, 0, 0, 1]);
+                pps_packet.extend_from_slice(pps);
+            }
+
+            (Some(sps_packet), Some(pps_packet))
+        } else {
+            (None, None)
+        };
+
+        Ok(RtpMuxer {
+            inner: blocking_muxer,
+            sps_packet_annex_b: sps_packet,
+            pps_packet_annex_b: pps_packet,
+        })
+    }
+
+    #[inline]
+    pub fn seq_and_timestamp(&self) -> (u16, u32) {
+        self.inner.seq_and_timestamp()
+    }
+
+    pub async fn muxed(
+        mut self,
+        packet: video::Packet,
+    ) -> (RtpMuxer, Result<Vec<video::rtp::RtpBuf>>) {
+        task::spawn_blocking(move || {
+            if packet.is_key() {
+                if let Some(sps_packet_data) = &self.sps_packet_annex_b {
+                    dbg!("sps"); // TODO
+                    let mut sps_packet = video_rs::Packet::new(
+                        video_rs::ffmpeg::Packet::copy(sps_packet_data),
+                        video_rs::ffmpeg::ffi::AV_TIME_BASE_Q.into(),
+                    );
+                    sps_packet.set_dts(packet.dts());
+                    sps_packet.set_pts(packet.pts());
+                    if let Err(err) = self.inner.mux(sps_packet) {
+                        return (self, Err(err));
+                    }
+                }
+                if let Some(pps_packet_data) = &self.pps_packet_annex_b {
+                    dbg!("pps"); // TODO
+                    let mut pps_packet = video_rs::Packet::new(
+                        video_rs::ffmpeg::Packet::copy(pps_packet_data),
+                        video_rs::ffmpeg::ffi::AV_TIME_BASE_Q.into(),
+                    );
+                    pps_packet.set_dts(packet.dts());
+                    pps_packet.set_pts(packet.pts());
+                    if let Err(err) = self.inner.mux(pps_packet) {
+                        return (self, Err(err));
+                    }
+                }
+            }
+            let out = self.inner.mux(packet);
+            (self, out)
+        })
         .await
         .unwrap()
+    }
+
+    pub async fn finish(mut self) -> Result<Option<Vec<video::rtp::RtpBuf>>> {
+        task::spawn_blocking(move || self.inner.finish())
+            .await
+            .unwrap()
+    }
 }

--- a/oddity-rtsp-server/src/media/video/rtp_muxer.rs
+++ b/oddity-rtsp-server/src/media/video/rtp_muxer.rs
@@ -27,12 +27,12 @@ impl RtpMuxer {
         let (sps_packet, pps_packet) = if !parameter_sets.is_empty() {
             let (sps, ppss) = parameter_sets.remove(0)?;
 
-            let mut sps_packet = vec![0, 0, 0, 1]; // annex b start code
+            let mut sps_packet = (sps.len() as u32).to_be_bytes().to_vec(); // AVCC start code
             sps_packet.extend_from_slice(sps);
 
             let mut pps_packet = Vec::new();
             for pps in ppss {
-                pps_packet.extend_from_slice(&[0, 0, 0, 1]);
+                pps_packet.extend_from_slice(&(pps.len() as u32).to_be_bytes());
                 pps_packet.extend_from_slice(pps);
             }
 
@@ -72,8 +72,7 @@ impl RtpMuxer {
                 if let Some(pps_packet_data) = &self.pps_packet_annex_b {
                     new_packet_data.extend_from_slice(pps_packet_data);
                 }
-                new_packet_data.extend_from_slice(&[0, 0, 0, 1]);
-                new_packet_data.extend_from_slice(&old_packet.data().unwrap()[4..]);
+                new_packet_data.extend_from_slice(old_packet.data().unwrap());
                 let mut new_packet =
                     video::Packet::new(video::ffmpeg::Packet::copy(&new_packet_data), time_base);
                 new_packet.set_dts(old_dts);


### PR DESCRIPTION
Still bugging out. This is what client side is seeing in terms of NALS after depacketization and everything:

[src/src/decode.rs:41:9] &nal[0..5.min(nal.len())] = [
    0,
    0,
    0,
    1,
    103,
]
[src/src/decode.rs:41:9] &nal[0..5.min(nal.len())] = [
    0,
    0,
    0,
    1,
    89,
]
[src/src/decode.rs:41:9] &nal[0..5.min(nal.len())] = [
    0,
    0,
    0,
    1,
    65,
]

(including annex b start codes ofc)

We're seeing 89 which is weird since we expect PPS there which is 104. Confirmed that our pps_packet_data starts with 104 so something is going wrong inside this:

```rust
                let old_dts = packet.dts();
                let old_pts = packet.pts();
                let (old_packet, time_base) = packet.into_inner_parts();
                let mut new_packet_data = Vec::new();
                if let Some(sps_packet_data) = &self.sps_packet_annex_b {
                    new_packet_data.extend_from_slice(sps_packet_data);
                }
                if let Some(pps_packet_data) = &self.pps_packet_annex_b {
                    new_packet_data.extend_from_slice(pps_packet_data);
                }
                new_packet_data.extend_from_slice(&[0, 0, 0, 1]);
                new_packet_data.extend_from_slice(&old_packet.data().unwrap()[4..]);
                let mut new_packet =
                    video::Packet::new(video::ffmpeg::Packet::copy(&new_packet_data), time_base);
                new_packet.set_dts(old_dts);
                new_packet.set_pts(old_pts);
```
Note I'm noteven sure if doing [4..] on old packet data makes sense (trying to remove the AVCC start code)